### PR TITLE
Fix: Nodes orphaned when reachable only through hidden-type edges

### DIFF
--- a/src/codeblock.ts
+++ b/src/codeblock.ts
@@ -205,20 +205,29 @@ class RelationsBlockChild extends MarkdownRenderChild {
 				return;
 			}
 			const familyDepth = this.options.depthExplicit ? effectiveDepth : undefined;
+			// buildFamilyNeighborhood applies the disabled-types filter internally,
+			// before the genealogy walk, so a hidden type can't pull an
+			// otherwise-invisible ancestor/descendant into the neighborhood.
 			graph = buildFamilyNeighborhood(this.app, this.settings, hostFile.path, familyDepth, this.cache);
 			highlightId = hostFile.path;
 		} else if (this.options.scope === "full") {
 			graph = buildFullGraph(this.app, this.settings, this.cache);
+			// `full` has no hop-limiting to worry about, so filtering order
+			// doesn't matter — apply it here same as before.
+			graph = filterGraphByTypes(graph, new Set(this.settings.disabledTypes), highlightId);
 		} else if (this.options.scope === "connected") {
 			if (!hostFile) {
 				canvas.createDiv({ cls: "relations-empty", text: "Could not resolve host note for connected graph." });
 				return;
 			}
+			// buildConnectedGraph applies the disabled-types filter internally,
+			// before the component is walked (see its JSDoc).
 			graph = buildConnectedGraph(this.app, this.settings, hostFile.path, this.cache);
 			// `connected` normally has no hop limit — it walks the whole
 			// component. But an explicitly written `depth:` shouldn't be
 			// silently ignored, and mini embeds always force a compact 1-hop
-			// view, so in either case bound the component by depth.
+			// view, so in either case bound the (already-filtered) component by
+			// depth.
 			if (this.options.depthExplicit || effectiveSize === "mini") {
 				graph = localSubgraph(graph, hostFile.path, effectiveDepth);
 			}
@@ -228,13 +237,11 @@ class RelationsBlockChild extends MarkdownRenderChild {
 				canvas.createDiv({ cls: "relations-empty", text: "Could not resolve host note for local graph." });
 				return;
 			}
+			// buildLocalGraph applies the disabled-types filter internally, before
+			// the hop-limited neighborhood is walked (see its JSDoc).
 			graph = buildLocalGraph(this.app, this.settings, hostFile.path, effectiveDepth, this.cache);
 			highlightId = hostFile.path;
 		}
-
-		// Honour the global type filter (shared with the side-panel view). The
-		// host/center note is kept even if filtering would otherwise isolate it.
-		graph = filterGraphByTypes(graph, new Set(this.settings.disabledTypes), highlightId);
 
 		if (graph.nodes.length === 0) {
 			canvas.createDiv({

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -17,6 +17,16 @@ import { GraphCache } from "./graph-cache";
  * Pure and side-effect-free — returns a new graph, leaving the input untouched —
  * so it's safe to apply to a cached graph without poisoning the cache. When
  * nothing is disabled it returns the original graph reference unchanged.
+ *
+ * For scope: local / connected / family, callers (buildLocalGraph,
+ * buildConnectedGraph, buildFamilyNeighborhood) apply this filter to the full
+ * graph BEFORE walking the hop-limited neighborhood, so hop distance is
+ * computed over the already-filtered edge set. A note reachable only through
+ * a disabled-type edge is excluded entirely rather than surfacing as a
+ * seemingly-disconnected orphan kept alive by some other edge of its own.
+ * When calling this function directly on an already hop-limited graph, that
+ * guarantee doesn't apply — filtering after the fact can still leave such
+ * orphans.
  */
 export function filterGraphByTypes(
 	graph: RelationsGraph,
@@ -161,6 +171,12 @@ export function buildFullGraph(
  *
  * The full graph is fetched via the same cache as `buildFullGraph` — local-graph
  * calls from multiple embeds on the same page reuse one scan.
+ *
+ * The global disabled-types filter is applied to the full graph BEFORE the
+ * hop-limited neighborhood is walked, so hop distance reflects only edges the
+ * user can actually see. A note reachable solely through a disabled-type edge
+ * is excluded entirely, rather than surfacing as an orphan kept alive by an
+ * unrelated visible edge of its own.
  */
 export function buildLocalGraph(
 	app: App,
@@ -180,7 +196,8 @@ export function buildLocalGraph(
 		return { nodes: [], edges: [] };
 	}
 
-	return localSubgraph(full, centerPath, depth);
+	const filtered = filterGraphByTypes(full, new Set(settings.disabledTypes), centerPath);
+	return localSubgraph(filtered, centerPath, depth);
 }
 
 /**
@@ -294,10 +311,15 @@ export function connectedComponent(
  * the vault including disconnected islands) and from `local` (which bounds
  * by hop count).
  *
- * Edge types are not filtered — any edge counts as a connection. A long
- * chain through friends-of-friends or mentor-of-rival will still be followed.
- * For tightly-bounded vaults this is the right thing; for vaults with lots
- * of weak side-relationships the connected component may grow large.
+ * Edge types that are globally disabled are removed from the full graph
+ * BEFORE the component is walked — a note reachable only through a
+ * disabled-type edge is excluded entirely rather than surfacing as a
+ * disconnected-looking orphan kept alive by some other visible edge of its
+ * own. What remains still follows arbitrarily long chains through
+ * friends-of-friends or mentor-of-rival; only the edge *types* are filtered,
+ * not the walk depth. For tightly-bounded vaults this is the right thing;
+ * for vaults with lots of weak side-relationships the connected component
+ * may grow large.
  */
 export function buildConnectedGraph(
 	app: App,
@@ -316,7 +338,8 @@ export function buildConnectedGraph(
 		}
 		return { nodes: [], edges: [] };
 	}
-	return connectedComponent(full, centerPath);
+	const filtered = filterGraphByTypes(full, new Set(settings.disabledTypes), centerPath);
+	return connectedComponent(filtered, centerPath);
 }
 
 /**
@@ -350,7 +373,11 @@ export function buildFamilyNeighborhood(
 		return { nodes: [], edges: [] };
 	}
 
-	return filterFamilyNeighborhood(full, focusPath, depth);
+	// Disabled types are stripped before the genealogy walk so a disabled
+	// parent/child relationship type can't pull an otherwise-hidden ancestor
+	// or descendant into the neighborhood.
+	const filtered = filterGraphByTypes(full, new Set(settings.disabledTypes), focusPath);
+	return filterFamilyNeighborhood(filtered, focusPath, depth);
 }
 
 export function filterFamilyNeighborhood(

--- a/src/view.ts
+++ b/src/view.ts
@@ -187,20 +187,23 @@ export class RelationsView extends ItemView {
 				this.showEmpty("No active note. Open a note to see its relationships.");
 				return;
 			}
+			// buildLocalGraph applies the disabled-types filter internally, before
+			// the hop-limited neighborhood is walked, so a note reachable only via
+			// a disabled-type edge is excluded entirely rather than surfacing as an
+			// orphan kept alive by some other edge of its own.
 			graph = buildLocalGraph(this.app, this.plugin.settings, active.path, this.currentLocalDepth, this.plugin.graphCache);
 			highlightId = active.path;
 		} else {
+			// `full` has no hop-limiting to worry about, so filtering order doesn't
+			// matter — apply the type filter here before measuring/rendering, so
+			// node counts, layout and the subtitle reflect only what's shown.
 			graph = buildFullGraph(this.app, this.plugin.settings, this.plugin.graphCache);
+			graph = filterGraphByTypes(
+				graph,
+				new Set(this.plugin.settings.disabledTypes),
+				highlightId,
+			);
 		}
-
-		// Apply the type filter before measuring/rendering, so node counts, layout
-		// and the subtitle reflect only what's actually shown. The active note
-		// (local mode) is kept even if filtering would otherwise isolate it.
-		graph = filterGraphByTypes(
-			graph,
-			new Set(this.plugin.settings.disabledTypes),
-			highlightId,
-		);
 
 		if (this.mode === "local") {
 			const active = this.app.workspace.getActiveFile();

--- a/tests/pre-filtered-neighborhood.test.ts
+++ b/tests/pre-filtered-neighborhood.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import { App, TFile } from "obsidian";
+import {
+	buildLocalGraph,
+	buildConnectedGraph,
+	buildFamilyNeighborhood,
+} from "../src/graph";
+import type { RelationsSettings, RelationshipType } from "../src/types";
+import { DEFAULT_SETTINGS } from "../src/types";
+
+/**
+ * Regression tests for the "hop-limited neighborhood walked over ALL edge
+ * types before the disabled-types filter" bug.
+ *
+ * Root cause: buildLocalGraph / buildConnectedGraph / buildFamilyNeighborhood
+ * computed reachability over the full, unfiltered graph, then filtered edges
+ * afterward (in codeblock.ts / view.ts). A note reachable ONLY through a
+ * disabled-type edge could still survive as an orphan if it happened to have
+ * its OWN edge of a still-enabled type — that edge kept it from being pruned
+ * as isolated, even though the edge that actually brought it into the
+ * neighborhood was invisible.
+ *
+ * Fixed by filtering disabledTypes BEFORE the hop-limited / connected-
+ * component / family walk, so hop distance is computed over only the edges
+ * the user can actually see.
+ *
+ * This reproduces the shape of the manually-discovered bug: a note (Varinka)
+ * with the "Family" type disabled showed her parent (Amalayin, reachable only
+ * via the now-hidden parent edge) and that parent's own still-enabled enemy
+ * (Kolimot), because Amalayin's enemy edge kept her from being pruned.
+ */
+
+interface FakeNote {
+	path: string;
+	frontmatter: Record<string, unknown>;
+}
+
+function makeFakeApp(notes: FakeNote[]): App {
+	const files = notes.map((n) => {
+		const f = new TFile();
+		f.path = n.path;
+		f.basename = n.path.replace(/\.md$/, "").split("/").pop() ?? n.path;
+		return f;
+	});
+	const byPath = new Map(files.map((f) => [f.path, f]));
+	const byBasename = new Map(files.map((f) => [f.basename.toLowerCase(), f]));
+	const fmByPath = new Map(notes.map((n) => [n.path, n.frontmatter]));
+
+	return {
+		vault: {
+			getMarkdownFiles: () => files,
+			getAbstractFileByPath: (p: string) => byPath.get(p) ?? null,
+			getResourcePath: (f: TFile) => `app://${f.path}`,
+		},
+		metadataCache: {
+			getFileCache: (f: TFile) => ({ frontmatter: fmByPath.get(f.path) }),
+			getFirstLinkpathDest: (link: string, _from: string) =>
+				byBasename.get(link.toLowerCase()) ?? null,
+		},
+	} as unknown as App;
+}
+
+function socialType(name: string, overrides: Partial<RelationshipType> = {}): RelationshipType {
+	return {
+		name,
+		color: "#22c55e",
+		symmetric: true,
+		pair: false,
+		treeLayout: false,
+		lineStyle: "solid",
+		genealogy: false,
+		...overrides,
+	};
+}
+
+function familyParentType(overrides: Partial<RelationshipType> = {}): RelationshipType {
+	return {
+		name: "parent",
+		color: "#b45309",
+		symmetric: false,
+		pair: false,
+		treeLayout: true,
+		lineStyle: "solid",
+		genealogy: true,
+		...overrides,
+	};
+}
+
+function spouseType(overrides: Partial<RelationshipType> = {}): RelationshipType {
+	return {
+		name: "spouse",
+		color: "#d946ef",
+		symmetric: true,
+		pair: true,
+		treeLayout: false,
+		lineStyle: "double",
+		genealogy: false,
+		...overrides,
+	};
+}
+
+function settingsWith(
+	types: RelationshipType[],
+	overrides: Partial<RelationsSettings> = {},
+): RelationsSettings {
+	return { ...DEFAULT_SETTINGS, relationshipTypes: types, ...overrides };
+}
+
+function ids(graph: { nodes: { id: string }[] }): string[] {
+	return graph.nodes.map((n) => n.id).sort();
+}
+
+describe("buildLocalGraph — pre-filtered hop distance (disabledTypes)", () => {
+	// Varinka --parent (disabled)--> Amalayin --enemy (enabled)--> Kolimot
+	// Varinka <--parent (disabled)-- Twice --ally (enabled)--> AllyA/B/C/D
+	const VAULT: FakeNote[] = [
+		{ path: "Varinka.md", frontmatter: { parent: ["[[Amalayin]]"] } },
+		{ path: "Amalayin.md", frontmatter: { enemy: ["[[Kolimot]]"] } },
+		{ path: "Kolimot.md", frontmatter: {} },
+		{ path: "Twice.md", frontmatter: { parent: ["[[Varinka]]"], ally: ["[[AllyA]]", "[[AllyB]]", "[[AllyC]]", "[[AllyD]]"] } },
+		{ path: "AllyA.md", frontmatter: {} },
+		{ path: "AllyB.md", frontmatter: {} },
+		{ path: "AllyC.md", frontmatter: {} },
+		{ path: "AllyD.md", frontmatter: {} },
+	];
+
+	const TYPES = [familyParentType(), socialType("enemy"), socialType("ally")];
+
+	it("excludes a node reachable only via a disabled-type edge, not just the disabled edge itself", () => {
+		const app = makeFakeApp(VAULT);
+		const settings = settingsWith(TYPES, { disabledTypes: ["parent"] });
+		const graph = buildLocalGraph(app, settings, "Varinka.md", 2, null);
+		// Amalayin/Kolimot and Twice/Ally* are only reachable through the disabled
+		// parent edges — with the fix they must not appear at all, not survive as
+		// a disconnected orphan cluster.
+		expect(ids(graph)).toEqual(["Varinka.md"]);
+		expect(graph.edges).toEqual([]);
+	});
+
+	it("still finds a node reachable via an enabled path even when a shorter disabled path also exists", () => {
+		// C --social--> A --parent(disabled)--> B
+		// C --social--> E --social--> B
+		// B is 2 hops out via the all-enabled C-E-B path, so it must still show
+		// at depth 2 — the fix must recompute hop distance, not blanket-exclude
+		// anything ever touched by a disabled edge. A is itself 1 hop from C via
+		// an enabled edge, so it stays too — only its onward (disabled) A-B edge
+		// is gone, meaning B is reached via E, not via A.
+		const app = makeFakeApp([
+			{ path: "C.md", frontmatter: { social: ["[[A]]", "[[E]]"] } },
+			{ path: "A.md", frontmatter: { parent: ["[[B]]"] } },
+			{ path: "E.md", frontmatter: { social: ["[[B]]"] } },
+			{ path: "B.md", frontmatter: {} },
+		]);
+		const settings = settingsWith([familyParentType(), socialType("social")], { disabledTypes: ["parent"] });
+		const graph = buildLocalGraph(app, settings, "C.md", 2, null);
+		expect(ids(graph)).toEqual(["A.md", "B.md", "C.md", "E.md"]);
+		const edgePairs = graph.edges.map((e) => `${e.source}->${e.target}`).sort();
+		expect(edgePairs).toEqual(["C.md->A.md", "C.md->E.md", "E.md->B.md"]);
+	});
+
+	it("retains the center note even when every visible edge is filtered away", () => {
+		const app = makeFakeApp(VAULT);
+		const settings = settingsWith(TYPES, { disabledTypes: ["parent", "enemy", "ally"] });
+		const graph = buildLocalGraph(app, settings, "Varinka.md", 2, null);
+		expect(ids(graph)).toEqual(["Varinka.md"]);
+		expect(graph.edges).toEqual([]);
+	});
+});
+
+describe("buildConnectedGraph — pre-filtered reachability (disabledTypes)", () => {
+	it("excludes a whole cluster reachable only through a disabled-type edge", () => {
+		const app = makeFakeApp([
+			{ path: "Varinka.md", frontmatter: { parent: ["[[Amalayin]]"] } },
+			{ path: "Amalayin.md", frontmatter: { enemy: ["[[Kolimot]]"] } },
+			{ path: "Kolimot.md", frontmatter: {} },
+		]);
+		const settings = settingsWith([familyParentType(), socialType("enemy")], { disabledTypes: ["parent"] });
+		const graph = buildConnectedGraph(app, settings, "Varinka.md", null);
+		expect(ids(graph)).toEqual(["Varinka.md"]);
+		expect(graph.edges).toEqual([]);
+	});
+
+	it("still walks arbitrarily far through an all-enabled chain", () => {
+		const app = makeFakeApp([
+			{ path: "A.md", frontmatter: { social: ["[[B]]"] } },
+			{ path: "B.md", frontmatter: { social: ["[[C]]"] } },
+			{ path: "C.md", frontmatter: { social: ["[[D]]"] } },
+			{ path: "D.md", frontmatter: {} },
+		]);
+		const settings = settingsWith([socialType("social")]);
+		const graph = buildConnectedGraph(app, settings, "A.md", null);
+		expect(ids(graph)).toEqual(["A.md", "B.md", "C.md", "D.md"]);
+	});
+});
+
+describe("buildFamilyNeighborhood — pre-filtered genealogy walk (disabledTypes)", () => {
+	it("excludes an ancestor's partner reachable only through a disabled parent edge", () => {
+		// Focus --parent (disabled)--> P --spouse (enabled)-- Q
+		const app = makeFakeApp([
+			{ path: "Focus.md", frontmatter: { parent: ["[[P]]"] } },
+			{ path: "P.md", frontmatter: { spouse: ["[[Q]]"] } },
+			{ path: "Q.md", frontmatter: {} },
+		]);
+		const settings = settingsWith([familyParentType(), spouseType()], { disabledTypes: ["parent"] });
+		const graph = buildFamilyNeighborhood(app, settings, "Focus.md", undefined, null);
+		// With the old pipeline, P and Q would survive as a disconnected pair
+		// (P-Q is an enabled spouse edge) even though the only path from Focus
+		// to P is the now-disabled parent edge.
+		expect(ids(graph)).toEqual(["Focus.md"]);
+		expect(graph.edges).toEqual([]);
+	});
+
+	it("still includes the ancestor and partner when the parent type is enabled", () => {
+		const app = makeFakeApp([
+			{ path: "Focus.md", frontmatter: { parent: ["[[P]]"] } },
+			{ path: "P.md", frontmatter: { spouse: ["[[Q]]"] } },
+			{ path: "Q.md", frontmatter: {} },
+		]);
+		const settings = settingsWith([familyParentType(), spouseType()]);
+		const graph = buildFamilyNeighborhood(app, settings, "Focus.md", undefined, null);
+		expect(ids(graph)).toEqual(["Focus.md", "P.md", "Q.md"]);
+	});
+});


### PR DESCRIPTION
Closes #28

## Overview
`scope: local`, `scope: connected`, and family-mode embeds could render a "ghost cluster" — a note (and sometimes its own further connections) with no visible edge back to the note you're actually looking at. It only happened when a relationship type had been disabled and the orphaned note also had an edge of a still-enabled type of its own.

## Root Cause
`buildLocalGraph`, `buildConnectedGraph`, and `buildFamilyNeighborhood` all computed the hop-limited neighborhood, connected component, or genealogy chain by walking the full, unfiltered graph — every edge type included, disabled or not. The disabled-types filter (`filterGraphByTypes`) was only applied _afterward_, in `codeblock.ts`/`view.ts`, once the neighborhood had already been decided.

That ordering meant a note reachable only through a disabled-type edge could still end up in the final graph: `filterGraphByTypes` prunes a node solely when it has zero remaining edges, and if that note happened to have its own edge of an enabled type (to some third note), that edge kept it — and its neighbors — from being pruned as isolated. The edge that actually explained _why_ the note was in view was the one that got hidden, so it rendered as a seemingly-disconnected orphan or cluster.

## Fix
Filter `disabledTypes` on the full graph before walking the neighborhood, not after, so hop distance / component reachability / genealogy-chain traversal only ever sees edges the user can actually see. A note reachable solely through a disabled-type edge is now excluded entirely instead of surfacing as an orphan. The center/focus note is still always retained even if it ends up with zero visible edges (unchanged guarantee).

`scope: full` is unaffected — it isn't hop-limited from a center note, so filtering before or after made no difference there; that call site still filters after building the full graph.

### Modified Source Files
File | Changes
-- | --
`src/graph.ts` | `buildLocalGraph`, `buildConnectedGraph`, and `buildFamilyNeighborhood` now apply `filterGraphByTypes` to the full graph (retaining the center/focus note) before calling `localSubgraph`, `connectedComponent`, and `filterFamilyNeighborhood` respectively, instead of leaving the caller to filter the already-built result. Updated JSDoc on `filterGraphByTypes` and the three build* functions to document the new pre-filtering guarantee.
`src/codeblock.ts` | Removed the redundant post-hoc `filterGraphByTypes` call for local/connected/family-mode embeds (now handled inside `graph.ts`); kept it for `scope: full` only, where filtering order doesn't matter.
`src/view.ts` | Same change for the side panel's local mode — dropped the redundant post-hoc filter now that `buildLocalGraph` filters internally; kept it for full-graph mode.
`tests/pre-filtered-neighborhood.test.ts` | New regression suite covering the bug directly.

Testing

- Added `tests/pre-filtered-neighborhood.test.ts` (7 tests) using a fake `App`/vault to reproduce the exact reported shape of the bug (a note whose only path in is a disabled-type edge, but which has its own enabled-type edge onward) across all three affected functions:
  - `buildLocalGraph` — the disabled-type-only note (and its own further edges) is now excluded entirely, not just the one hidden edge; a companion test confirms a node still reachable via an _enabled_ path at the correct hop count is not over-excluded, so hop-distance recomputation doesn't regress into a blanket ban on anything a disabled edge ever touched.
  - `buildConnectedGraph` — same orphan-exclusion case, plus a check that unbounded traversal through an all-enabled chain still works.
  - `buildFamilyNeighborhood` — an ancestor's partner reachable only through a disabled parent edge is excluded; re-enabling that type restores it.
  - Center/focus-note retention with zero visible edges is exercised throughout (existing guarantee, unchanged).
- Full suite: node `"node_modules\vitest\vitest.mjs" run` → 172/172 passing (17 test files).
- node `"node_modules\typescript\bin\tsc" -noEmit -skipLibCheck` → clean.
- No `main.js diff` from local verification builds.