### PR TITLE
fix: type-row grid was missing a column

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -418,7 +418,7 @@
 .relations-types-header,
 .relations-types-row {
 	display: grid;
-	grid-template-columns: 1fr 0.7fr 50px 50px 50px 50px 50px 90px 32px;
+	grid-template-columns: 1fr 0.7fr 50px 50px 50px 50px 50px 50px 90px 32px;
 	gap: 8px;
 	align-items: center;
 	padding: 4px 0;


### PR DESCRIPTION
Closes #33

## Overview

The Connection Types table in Settings → Relations rendered each relationship-type row across two lines instead of one, with the line-style dropdown truncated and the remove (✕) button wrapping onto its own bar below the row.

<img width="799" height="698" alt="Image" src="https://github.com/user-attachments/assets/a3198ed3-2cf9-4613-b1f0-47ccc652d746" />

## Root Cause

`.relations-types-row` / `.relations-types-header` declare `grid-template-columns` with only 9 tracks, but each row renders 10 cells: name, group, color, 5 checkboxes (Sym/Pair/Tree/Gen/Child), line-style select, and the remove button. The missing track shifted every column after Color by one — Child was stretched into the 90px track meant for the line-style select, the select was squeezed into the 32px track meant for the remove button (hence the truncated "soli"/"dou" text), and the remove button had no track left, so the grid auto-placed it onto an implicit new row.

## Fix

Added the missing `50px` track so all 6 fixed-width cells (Color + 5 checkboxes) get their own column, restoring the line-style select to 90px and the remove button to 32px inline at the end of the row.

### Modified Source Files

| File | Changes |
| -- | -- |
| `styles.css` | +1/-1 — add missing grid-template-columns track |

## Testing
- ✅ tsc compilation: 0 errors
- ✅ Full vitest suite: 165/165 tests passing
- ✅ Manually verified in-vault: Connection Types rows now render on a single line each, with the line-style dropdown fully readable and the ✕ remove button aligned inline at the end of the row