### PR TITLE
Fix/#21 asymmetrical genealogy

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -138,9 +138,49 @@ export function buildFullGraph(
 		if (node) nodes.push(node);
 	}
 
-	const edges = dedupeEdges(rawEdges.filter(
+	// Deduplicate edges first, filtering to valid path combinations. For a
+	// mutually-declared genealogy bond (e.g. Amalayin's `children:` AND
+	// Varinka's `parents:` both naming the same pair), dedupeEdges keeps
+	// whichever raw edge appears first — which depended on vault scan order
+	// and could flip the displayed type/color across reloads. A stable sort
+	// moves declaresChild-sourced edges (the parent's own claim) after
+	// plain child-declared ones beforehand, so the child's own declaration
+	// deterministically wins the tie regardless of scan order. Edges for
+	// different pairs are never affected by dedup either way, but this also
+	// makes family-connectors.ts's single shared tree-color pick (which
+	// reads the first genealogy edge in this array) consistently prefer the
+	// child-declared type, matching what a plain single-genealogy-type
+	// vault has always shown.
+	const dedupeOrdered = [...rawEdges.filter(
 		(e) => notePaths.has(e.source) && notePaths.has(e.target),
-	));
+	)].sort((a, b) => {
+		if (!a.genealogy || !b.genealogy) return 0;
+		const aDeclaresChild = typeMap.get(a.type.toLowerCase())?.declaresChild ?? false;
+		const bDeclaresChild = typeMap.get(b.type.toLowerCase())?.declaresChild ?? false;
+		return Number(aDeclaresChild) - Number(bDeclaresChild);
+	});
+	const edges = dedupeEdges(dedupeOrdered);
+
+	// A genealogy edge produced solely by a declaresChild type (the parent's
+	// note naming the child, e.g. `children: [[Kid]]`) is only as trustworthy
+	// as the parent's own claim unless the child's note names them back (via
+	// any non-declaresChild genealogy type, e.g. `parents: [[Mom]]`). Mark the
+	// unconfirmed ones so downstream neighborhood walks (family-tree,
+	// local/connected graph) let the parent's view reach the child through
+	// them without also letting the child's view reach the parent — see
+	// localSubgraph, connectedComponent, and filterFamilyNeighborhood below.
+	const childConfirmedPairs = new Set<string>();
+	for (const e of rawEdges) {
+		if (!e.genealogy) continue;
+		const type = typeMap.get(e.type.toLowerCase());
+		if (type?.declaresChild) continue;
+		childConfirmedPairs.add(`${e.source}|${e.target}`);
+	}
+	for (const e of edges) {
+		if (e.genealogy && !childConfirmedPairs.has(`${e.source}|${e.target}`)) {
+			e.genealogyOneWay = true;
+		}
+	}
 
 	const result = { nodes, edges };
 	if (cache) cache.set(settings, result);
@@ -200,12 +240,14 @@ export function localSubgraph(
 		return { nodes: [], edges: [] };
 	}
 
-	// adjacency map (undirected for traversal purposes — we want hops regardless of edge direction)
+	// adjacency map (undirected for traversal purposes — we want hops regardless of edge
+	// direction). Exception: a genealogyOneWay edge only lets the parent (target) reach
+	// the child (source), not the reverse — see the GraphEdge.genealogyOneWay doc.
 	const adj = new Map<string, Set<string>>();
 	for (const e of full.edges) {
 		if (!adj.has(e.source)) adj.set(e.source, new Set());
 		if (!adj.has(e.target)) adj.set(e.target, new Set());
-		adj.get(e.source)!.add(e.target);
+		if (!e.genealogyOneWay) adj.get(e.source)!.add(e.target);
 		adj.get(e.target)!.add(e.source);
 	}
 
@@ -258,11 +300,13 @@ export function connectedComponent(
 	if (!graph.nodes.some((n) => n.id === centerPath)) {
 		return { nodes: [], edges: [] };
 	}
+	// See localSubgraph — a genealogyOneWay edge only lets the parent (target)
+	// reach the child (source), not the reverse.
 	const adj = new Map<string, Set<string>>();
 	for (const e of graph.edges) {
 		if (!adj.has(e.source)) adj.set(e.source, new Set());
 		if (!adj.has(e.target)) adj.set(e.target, new Set());
-		adj.get(e.source)!.add(e.target);
+		if (!e.genealogyOneWay) adj.get(e.source)!.add(e.target);
 		adj.get(e.target)!.add(e.source);
 	}
 	const visited = new Set<string>([centerPath]);
@@ -368,10 +412,17 @@ export function filterFamilyNeighborhood(
 
 	for (const e of full.edges) {
 		if (e.genealogy) {
-			if (!parentsOf.has(e.source)) parentsOf.set(e.source, new Set());
+			// childrenOf is always populated — the parent's own descendant walk
+			// trusts their own declaration regardless of what the child's note
+			// says. parentsOf (the child's ancestor walk) only gets a
+			// genealogyOneWay edge's target when the child's own note confirms
+			// it; see the GraphEdge.genealogyOneWay doc.
 			if (!childrenOf.has(e.target)) childrenOf.set(e.target, new Set());
-			parentsOf.get(e.source)!.add(e.target);
 			childrenOf.get(e.target)!.add(e.source);
+			if (!e.genealogyOneWay) {
+				if (!parentsOf.has(e.source)) parentsOf.set(e.source, new Set());
+				parentsOf.get(e.source)!.add(e.target);
+			}
 		}
 		if (e.pair) {
 			if (!partnersOf.has(e.source)) partnersOf.set(e.source, new Set());

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -420,7 +420,7 @@ export class RelationsSettingTab extends PluginSettingTab {
 			makeCheckbox("pair",      "Pair — pull these nodes very close (e.g. spouse)");
 			makeCheckbox("treeLayout","Tree — lay out top-down when this type dominates");
 			makeCheckbox("genealogy", "Genealogy — bloodline edge for family-graph mode");
-			makeCheckbox("declaresChild", "Child — this property is written on the PARENT's note and names the child (e.g. `children:`). Only used when Gen is on; edges are stored child→parent either way, so both sides of a bond can be declared without duplicates.");
+			makeCheckbox("declaresChild", "Child — this property is written on the PARENT's note and names the child (e.g. `children:`). Only used when Gen is on; edges are stored child→parent either way, so both sides of a bond can be declared without duplicates. Unless the child's own note also names the parent back (via any non-Child genealogy property, e.g. `parents:`), the bond is one-way: it shows up in the parent's family-tree and local/connected graph views, but not the child's.");
 
 			// Line style dropdown
 			const lineSelect = row.createEl("select", { cls: "relations-types-linestyle" });

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,16 @@ export interface GraphEdge {
 	pair: boolean;
 	lineStyle: LineStyle;
 	genealogy: boolean;
+	// True when this genealogy edge exists only because the parent's note
+	// declared it (a declaresChild type, e.g. `children: [[Kid]]`) with no
+	// matching declaration on the child's own note (e.g. `parents: [[Mom]]`).
+	// Such a bond is trusted only for traversal that starts at the parent —
+	// the parent's own family-tree and local/connected graph views reach the
+	// child through it, but the child's own views don't reach the parent,
+	// since the child's note makes no such claim. Undefined/false for
+	// ordinary child-declared or mutually-declared bonds, which are trusted
+	// in both directions same as always.
+	genealogyOneWay?: boolean;
 }
 
 export interface RelationsGraph {

--- a/tests/declares-child.test.ts
+++ b/tests/declares-child.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { App, TFile } from "obsidian";
-import { buildFullGraph, dedupeEdges, filterFamilyNeighborhood } from "../src/graph";
+import {
+	buildFullGraph,
+	connectedComponent,
+	dedupeEdges,
+	filterFamilyNeighborhood,
+	localSubgraph,
+} from "../src/graph";
 import type { GraphEdge, RelationsSettings, RelationshipType } from "../src/types";
 import { DEFAULT_SETTINGS } from "../src/types";
 
@@ -158,6 +164,47 @@ describe("declaresChild normalization (issue #21)", () => {
 		]);
 	});
 
+	it("resolves a both-sides-declared bond to the child-declared type, regardless of scan order", () => {
+		// dedupeEdges keeps whichever raw edge for a pair was scanned first.
+		// Which file Obsidian's vault scan lists first shouldn't be able to flip
+		// which type -- and therefore which color -- represents the bond, since
+		// family-connectors.ts's family-tree view reads the type/color off
+		// whichever genealogy edge happens to be first in the final array.
+		const declaresChildFirst = makeFakeApp([
+			{ path: "Amalayin.md", frontmatter: { children: ['[[Varinka]]'] } },
+			{ path: "Varinka.md", frontmatter: { parents: ['[[Amalayin]]'] } },
+		]);
+		const childDeclaredFirst = makeFakeApp([
+			{ path: "Varinka.md", frontmatter: { parents: ['[[Amalayin]]'] } },
+			{ path: "Amalayin.md", frontmatter: { children: ['[[Varinka]]'] } },
+		]);
+
+		for (const app of [declaresChildFirst, childDeclaredFirst]) {
+			const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
+			const bond = graph.edges.find(
+				(e) => e.source === "Varinka.md" && e.target === "Amalayin.md",
+			);
+			expect(bond?.type).toBe("parents");
+		}
+	});
+
+	it("keeps a child-declared bond ahead of an unrelated declares-child-only pair in the edge list", () => {
+		// family-connectors.ts draws the whole family tree in ONE shared color,
+		// read from graph.edges.find(e => e.genealogy) -- whichever genealogy
+		// edge is first. Varinka->Twice has no complementary `parents:`
+		// declaration at all (Twice.md's is empty), so it must never be able to
+		// out-rank the mutually-declared Varinka/Amalayin bond just because its
+		// file happened to scan first.
+		const app = makeFakeApp([
+			{ path: "Varinka.md", frontmatter: { parents: ['[[Amalayin]]'], children: ['[[Twice]]'] } },
+			{ path: "Amalayin.md", frontmatter: { children: ['[[Varinka]]'] } },
+			{ path: "Twice.md", frontmatter: { parents: [] } },
+		]);
+		const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
+		const firstGenealogyEdge = graph.edges.find((e) => e.genealogy);
+		expect(firstGenealogyEdge?.type).toBe("parents");
+	});
+
 	it("family neighborhood from the grandparent reaches the children-only grandchild", () => {
 		const app = makeFakeApp(ISSUE_21_VAULT);
 		const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
@@ -229,5 +276,114 @@ describe("dedupeEdges genealogy pair-dedupe", () => {
 			lineStyle: "solid", genealogy: false,
 		});
 		expect(dedupeEdges([ally("A", "B"), ally("B", "A")])).toHaveLength(1);
+	});
+});
+
+/**
+ * A parent-declared ("declaresChild") bond with no reciprocal declaration on
+ * the child's own note is trusted only for traversal starting at the parent —
+ * the parent's own family-tree/local/connected-graph view reaches the child,
+ * but the child's view does not reach the parent. This stops a unilateral
+ * `children:` claim from pulling the "child" — and everyone connected to
+ * them — into every view of the claiming parent, while still letting the
+ * parent's own descendant chain (and views centered above the parent) work.
+ * A plain child-declared type (e.g. `parents:`) or a mutually-declared bond
+ * is unaffected — both keep working bidirectionally as always.
+ */
+function allyType(name: string): RelationshipType {
+	return {
+		name,
+		color: "#22c55e",
+		symmetric: true,
+		pair: false,
+		treeLayout: false,
+		lineStyle: "solid",
+		genealogy: false,
+	};
+}
+
+describe("genealogyOneWay: unreciprocated declares-child bonds don't grant upward reach", () => {
+	it("tags an edge genealogyOneWay when only the parent's side declares it", () => {
+		const app = makeFakeApp(ISSUE_21_VAULT);
+		const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
+		const twiceToVarinka = graph.edges.find(
+			(e) => e.source === "Twice.md" && e.target === "Varinka.md",
+		);
+		expect(twiceToVarinka?.genealogyOneWay).toBe(true);
+	});
+
+	it("does not tag a mutually-declared edge genealogyOneWay", () => {
+		const app = makeFakeApp(ISSUE_21_VAULT);
+		const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
+		const varinkaToAmalayin = graph.edges.find(
+			(e) => e.source === "Varinka.md" && e.target === "Amalayin.md",
+		);
+		expect(varinkaToAmalayin?.genealogyOneWay).toBeFalsy();
+	});
+
+	it("does not tag a plain child-declared type genealogyOneWay, even unreciprocated", () => {
+		// The default single-genealogy-type setup (just `parent:`, declaresChild
+		// unset) has no complementary declaresChild type to reciprocate with —
+		// it must keep working exactly as it always has.
+		const app = makeFakeApp([
+			{ path: "Kid.md", frontmatter: { parent: ['[[Mom]]'] } },
+			{ path: "Mom.md", frontmatter: {} },
+		]);
+		const graph = buildFullGraph(app, settingsWith([genType("parent")]));
+		expect(graph.edges[0].genealogyOneWay).toBeFalsy();
+	});
+
+	it("family neighborhood from the parent reaches the unconfirmed child", () => {
+		const app = makeFakeApp(ISSUE_21_VAULT);
+		const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
+		const fromVarinka = filterFamilyNeighborhood(graph, "Varinka.md");
+		expect(fromVarinka.nodes.map((n) => n.id).sort()).toEqual([
+			"Amalayin.md", "Twice.md", "Varinka.md",
+		]);
+	});
+
+	it("family neighborhood from the unconfirmed child does not reach the parent", () => {
+		const app = makeFakeApp(ISSUE_21_VAULT);
+		const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
+		const fromTwice = filterFamilyNeighborhood(graph, "Twice.md");
+		expect(fromTwice.nodes.map((n) => n.id)).toEqual(["Twice.md"]);
+	});
+
+	it("local graph centered on the unconfirmed child does not pull in the parent (or the parent's other connections)", () => {
+		const app = makeFakeApp([
+			{ path: "Amalayin.md", frontmatter: { children: ['[[Varinka]]'] } },
+			{
+				path: "Varinka.md",
+				frontmatter: {
+					parents: ['[[Amalayin]]'],
+					children: ['[[Twice]]'],
+					allies: ['[[Garath]]'],
+				},
+			},
+			{ path: "Twice.md", frontmatter: { parents: [] } },
+			{ path: "Garath.md", frontmatter: {} },
+		]);
+		const graph = buildFullGraph(app, settingsWith([...ISSUE_21_TYPES, allyType("allies")]));
+
+		const fromTwice = localSubgraph(graph, "Twice.md", 2);
+		expect(fromTwice.nodes.map((n) => n.id)).toEqual(["Twice.md"]);
+
+		const fromVarinka = localSubgraph(graph, "Varinka.md", 2);
+		expect(fromVarinka.nodes.map((n) => n.id).sort()).toEqual([
+			"Amalayin.md", "Garath.md", "Twice.md", "Varinka.md",
+		]);
+	});
+
+	it("connected component containing the unconfirmed child excludes the parent", () => {
+		const app = makeFakeApp(ISSUE_21_VAULT);
+		const graph = buildFullGraph(app, settingsWith(ISSUE_21_TYPES));
+
+		const fromTwice = connectedComponent(graph, "Twice.md");
+		expect(fromTwice.nodes.map((n) => n.id)).toEqual(["Twice.md"]);
+
+		const fromVarinka = connectedComponent(graph, "Varinka.md");
+		expect(fromVarinka.nodes.map((n) => n.id).sort()).toEqual([
+			"Amalayin.md", "Twice.md", "Varinka.md",
+		]);
 	});
 });


### PR DESCRIPTION
# fix: #21 make unreciprocated declares-child bonds one-way

## Summary

Follow-up to the original `declaresChild` fix for #21. That fix made an asymmetrical genealogy declaration (e.g. a parent's `children:` naming a child who doesn't declare `parents:` back) render as a single, correctly-directed bond instead of a missing node or a duplicate/conflicting edge. In practice, though, treating that bond as fully bidirectional went too far: a parent's unilateral `children:` claim could pull the "child" — and everyone connected to them — into every view of the claiming parent, including the child's own family-tree and local/connected graph views, even though the child's own note made no such claim.

This PR makes that trust directional: **a `declaresChild`-only bond is trusted for traversal starting at the parent, not the reverse**, unless the child's own note names the parent back via any non-`declaresChild` genealogy type (e.g. `parents:`).

It also fixes a related nondeterminism uncovered while testing this: `dedupeEdges` kept whichever raw edge for a mutually-declared genealogy pair was scanned first, which depended on vault file-listing order and could flip the displayed type/color across reloads.

## Problem

Given:

```yaml
# Amalayin.md
children: [[Varinka]]
```

```yaml
# Varinka.md
parents: [[Amalayin]]
children: [[Twice]]
```

```yaml
# Twice.md
parents: []
```

With `parents` and `children` both marked Genealogy (`children` also marked Child/`declaresChild`), Twice's family-tree and local/connected graph views showed Varinka — and Varinka's entire unrelated social circle at hop 2 — even though Twice's own note never claims Varinka as a parent. Only Varinka's own `children:` declaration put that bond there.

Separately, the same mutually-declared bond (Amalayin ↔ Varinka, declared from both sides via different property names) could render in either `parents`' or `children`'s color depending on which file Obsidian's vault scan happened to list first — non-deterministic across reloads, and confusing since `family-connectors.ts` draws the whole family-tree in one shared stroke color read from the first genealogy edge in the array.

## Fix

**One-way trust** (`src/graph.ts`, `src/types.ts`):
- `GraphEdge` gains `genealogyOneWay?: boolean`, set in `buildFullGraph` when a genealogy edge exists only because of a `declaresChild`-type declaration with no reciprocal declaration on the child's own note.
- `localSubgraph` and `connectedComponent`'s adjacency maps let the parent (edge target) reach the child (edge source) through a one-way edge, but not the reverse.
- `filterFamilyNeighborhood`'s descendant walk (`childrenOf`) always trusts the parent's own claim (so an ancestor's view still descends correctly through the whole chain); the ancestor walk (`parentsOf`) only follows confirmed edges.
- A plain single-genealogy-type setup (just `parent:`, no `declaresChild` type at all) is unaffected — this only changes behavior for genealogy types with `declaresChild: true` that lack reciprocation.
- Updated the "Child" checkbox's settings tooltip (`src/settings.ts`) to describe the new one-way behavior.

**Deterministic dedupe ordering** (`src/graph.ts`):
- Raw edges are stable-sorted before `dedupeEdges` runs so a plain child-declared type always sorts ahead of a `declaresChild` type for genealogy edges. `dedupeEdges`'s existing "first occurrence wins" logic then deterministically keeps the child-declared type for a mutually-declared bond, regardless of vault scan order — no changes to `dedupeEdges` itself.

## Testing

- 9 new tests in `tests/declares-child.test.ts`:
  - `genealogyOneWay` is set correctly (unreciprocated declares-child edge, mutually-declared edge, and the default single-type setup which must stay unaffected).
  - Family neighborhood: the parent's view reaches the unconfirmed child; the child's view does not reach the parent.
  - `localSubgraph`: local graph centered on the unconfirmed child doesn't pull in the parent or the parent's other connections; centered on the parent, it does.
  - `connectedComponent`: same containment check.
  - Dedupe determinism: a mutually-declared bond resolves to the child-declared type regardless of which file is scanned first; a child-declared bond stays ahead of an unrelated declares-child-only pair in the edge list (the fact `family-connectors.ts` relies on for its shared tree color).
- Full suite: 350 tests passing, `tsc --noEmit` clean.
- Manually verified in Obsidian against the reproduction vault (Amalayin/Varinka/Twice): Twice's family-tree and local graph no longer show Varinka or her connections; Varinka's and Amalayin's views still show the full chain; the chain renders consistently in the `parents` color across repeated reloads.

## Notes for reviewers

- No changes to `dedupeEdges`'s signature or logic — the ordering fix is a pre-sort of its input, keeping the type-name-preserving, no-hardcoded-field-name approach from the original #21 fix.
- `main.js` is intentionally not included in this PR; left to the maintainer's release build process.